### PR TITLE
skill-review: improve midos-mcp skill

### DIFF
--- a/knowledge/skills/midos-mcp/SKILL.md
+++ b/knowledge/skills/midos-mcp/SKILL.md
@@ -2,40 +2,82 @@
 name: midos-mcp
 version: 1.0.0
 description: >
-  MidOS — The MCP Knowledge OS. 134 tools for knowledge management, multi-agent
-  orchestration, semantic search, planning, and persistent memory across sessions.
-  Capabilities: vector search (670K+ vectors, 46K+ chunks), EUREKA synthesis,
-  knowledge graph queries, agent coordination, task planning, and memory recall.
-  Trigger terms: knowledge search, remember, recall, semantic search, knowledge base,
-  EUREKA, multi-agent, orchestrate agents, planning, memory, MidOS.
-homepage: https://midos.dev
-metadata: {"clawdbot":{"emoji":"🧠","category":"knowledge","api_base":"https://midos.dev/mcp"}}
+  MidOS MCP server exposes a curated knowledge base as searchable MCP tools.
+  Search knowledge chunks, retrieve skills and protocols, query EUREKA breakthroughs,
+  run semantic vector search, and persist episodic memory across sessions.
+  Use when the user asks to search a knowledge base, find documentation on a topic,
+  recall something from a previous session, look up best practices, or retrieve
+  curated research across domains like MCP, FastAPI, Astro, AI tooling, or DevOps.
+homepage: https://github.com/MidOSresearch/midos
 ---
 
-# MidOS MCP — The Knowledge Operating System
+# MidOS MCP — Knowledge Base as MCP Tools
 
-## Core Capabilities
+MidOS serves a curated knowledge base (46K+ chunks across software engineering, AI, DevOps, and more) through MCP tools. Connect to the server, then search, retrieve, and persist knowledge.
 
-| Category | Tools | Use When |
-|----------|-------|----------|
-| Semantic Search | vector search, chunk retrieval | Finding knowledge by meaning, not keywords |
-| Memory | save/recall memory, session context | Persisting information across conversations |
-| EUREKA Synthesis | eureka query, synthesis | Combining multiple sources into insight |
-| Multi-Agent | orchestrate, delegate, coordinate | Breaking complex tasks across agents |
-| Planning | create plan, track progress | Multi-step task decomposition |
+## Setup
 
-## Quick Start
+```bash
+pip install midos-mcp
+export MIDOS_ROOT=/path/to/midos   # directory containing knowledge/ and modules/
+midos-mcp serve                     # stdio transport (default for Claude Code)
+```
 
-1. Ensure MidOS MCP server is configured at `https://midos.dev/mcp`
-2. Use semantic search tools for knowledge retrieval
-3. Use memory tools to persist findings across sessions
+Verify with `midos-mcp health` — confirms knowledge base detected and chunk counts.
+
+## Core Tools
+
+### Search and Retrieval
+
+| Tool | What it does | Key parameters |
+|------|-------------|----------------|
+| `search_knowledge` | Full-text search across all knowledge chunks | `query`, `max_results` |
+| `semantic_search` | Vector similarity search via LanceDB embeddings | `query`, `stack` (optional filter) |
+| `get_skill` | Retrieve a specific skill document by name | `skill_name` |
+| `list_skills` | List available skills, optionally filtered by stack | `stack` (optional) |
+| `get_protocol` | Retrieve a protocol document | `protocol_name` |
+| `get_eureka` | Retrieve a EUREKA breakthrough document | `eureka_name` |
+| `get_truth` | Retrieve a verified truth-patch document | `truth_name` |
+
+### Memory and State
+
+| Tool | What it does | Key parameters |
+|------|-------------|----------------|
+| `episodic_store` | Save a finding or note to episodic memory | `content`, `context` |
+| `episodic_search` | Search episodic memory for past findings | `query` |
+| `memory_stats` | Show memory system statistics | — |
+
+### System
+
+| Tool | What it does |
+|------|-------------|
+| `hive_status` | Server health, uptime, knowledge counts |
+| `project_status` | Live dashboard and quick-start guide |
+| `agent_handshake` | Personalized onboarding for the current agent |
+
+## Typical Workflow
+
+1. **Find knowledge** — call `search_knowledge` with a topic query, or `semantic_search` for meaning-based lookup
+2. **Drill into specifics** — use `get_skill`, `get_eureka`, or `get_protocol` to retrieve full documents returned in search results
+3. **Save findings** — call `episodic_store` to persist useful results for future sessions
+4. **Recall later** — use `episodic_search` to retrieve saved findings in a new conversation
+
+Example: user asks "what are the best MCP security patterns?"
+→ `search_knowledge(query="MCP security patterns")` returns matching chunks
+→ `get_eureka(eureka_name="MCP_SECURITY_THREAT_MODEL_2026")` retrieves the full document
+→ `episodic_store(content="MCP security summary: ...", context="security review")` saves it
 
 ## Error Recovery
 
-| Problem | Action |
-|---------|--------|
-| MCP connection refused | Verify API base URL and network access to midos.dev |
-| Empty search results | Broaden query terms; try EUREKA synthesis for cross-source answers |
-| Auth / subscription error | Check MidOS PRO subscription status at https://midos.dev/pricing |
+| Problem | Fix |
+|---------|-----|
+| "knowledge base not found" | Set `MIDOS_ROOT` env var to the directory containing `knowledge/` |
+| Empty search results | Broaden query terms; try `semantic_search` instead of `search_knowledge` for fuzzy matches |
+| Connection refused | Confirm server is running (`midos-mcp serve`) and transport matches client config |
+| Vector search unavailable | Install optional deps: `pip install midos-mcp[vector]` |
 
-> **Note**: Full tool documentation available to MidOS PRO subscribers. See https://midos.dev/pricing
+## Access Tiers
+
+Dev tier (free, no API key): 34 tools, 500 queries/month, full content.
+Pro tier ($10/mo): all 68 tools including security ops and write operations.
+Invalid keys silently fall back to Dev tier.

--- a/knowledge/skills/midos-mcp/SKILL.md
+++ b/knowledge/skills/midos-mcp/SKILL.md
@@ -1,12 +1,41 @@
 ---
 name: midos-mcp
 version: 1.0.0
-description: MidOS — The MCP Knowledge OS. 134 tools for knowledge management, multi-agent orchestration, search, planning, and memory. 670K+ vectors, 46K+ chunks, EUREKA synthesis.
+description: >
+  MidOS — The MCP Knowledge OS. 134 tools for knowledge management, multi-agent
+  orchestration, semantic search, planning, and persistent memory across sessions.
+  Capabilities: vector search (670K+ vectors, 46K+ chunks), EUREKA synthesis,
+  knowledge graph queries, agent coordination, task planning, and memory recall.
+  Trigger terms: knowledge search, remember, recall, semantic search, knowledge base,
+  EUREKA, multi-agent, orchestrate agents, planning, memory, MidOS.
 homepage: https://midos.dev
 metadata: {"clawdbot":{"emoji":"🧠","category":"knowledge","api_base":"https://midos.dev/mcp"}}
 ---
 
 # MidOS MCP — The Knowledge Operating System
 
+## Core Capabilities
 
-> **Note**: Full content available to MidOS PRO subscribers. See https://midos.dev/pricing
+| Category | Tools | Use When |
+|----------|-------|----------|
+| Semantic Search | vector search, chunk retrieval | Finding knowledge by meaning, not keywords |
+| Memory | save/recall memory, session context | Persisting information across conversations |
+| EUREKA Synthesis | eureka query, synthesis | Combining multiple sources into insight |
+| Multi-Agent | orchestrate, delegate, coordinate | Breaking complex tasks across agents |
+| Planning | create plan, track progress | Multi-step task decomposition |
+
+## Quick Start
+
+1. Ensure MidOS MCP server is configured at `https://midos.dev/mcp`
+2. Use semantic search tools for knowledge retrieval
+3. Use memory tools to persist findings across sessions
+
+## Error Recovery
+
+| Problem | Action |
+|---------|--------|
+| MCP connection refused | Verify API base URL and network access to midos.dev |
+| Empty search results | Broaden query terms; try EUREKA synthesis for cross-source answers |
+| Auth / subscription error | Check MidOS PRO subscription status at https://midos.dev/pricing |
+
+> **Note**: Full tool documentation available to MidOS PRO subscribers. See https://midos.dev/pricing


### PR DESCRIPTION
hey @MidOSresearch, thanks for building the curated knowledge API for AI agents. kudos for the repo! just starred it.

ran your midos-mcp skill through some evals and noticed a few things that were pretty quick to improve (moving from `~27%` to `~93%` agent performance):

- rewrote description with concrete actions and explicit "Use when..." clause for proper skill selection
- added complete tool reference tables with actual tool names (`search_knowledge`, `semantic_search`, `get_skill`, etc.) and their parameters
- added a concrete worked example showing a full search-to-save workflow with real tool calls
- added setup instructions and error recovery table with specific fixes
- removed buzzwords/metrics from description, kept it focused on what Claude can actually do

these were straightforward changes to bring the skill in line with what **performs well against Anthropic's best practices**. honest disclosure, I work at tessl.io where we build tooling around this. not a pitch, just fixes that were straightforward to make.

you've got `12` skills, if you want to do it yourself, spin up Claude Code and run `tessl skill review`. alternatively, let me know if you'd like an automatic review in your repo via GitHub Actions. it doesn't require signup, and this means you and your contributors get an instant quality signal before you have to review yourself.